### PR TITLE
Keep necessary reload from air

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -4,7 +4,7 @@ tmp_dir = "bin"
 [build]
   args_bin = []
   bin = "./bin/main"
-  cmd = "npm run build && go build -tags local -o ./bin/main cmd/main/main.go"
+  cmd = "make notify-templ-proxy && npm run build && go build -tags local -o ./bin/main cmd/main/main.go"
   delay = 1000
   exclude_dir = ["tmp", "bin"]
   exclude_file = []


### PR DESCRIPTION
We need to keep the rebuild from air. Templ refreshes the proxy but it's too early, air hasn't rebuilt the binary yet.